### PR TITLE
Minimize window to tray

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   </head>
 
   <body>
+    
     <div class="progress mb-2" style="border-radius: 0px">
       <div class="progress-bar bg-primary"></div>
     </div>
@@ -56,6 +57,14 @@
         Start
       </button>
     </div>
+
+      <!-- Toggle for minimize window to tray -->
+      <div class=" d-flex justify-content-center gap-2 small">
+        <input 
+         id="trayToggle"
+         type="checkbox">
+        <span>Minimize window to tray</span>
+      </div>
 
     <!-- You can also require other files to run in this process -->
     <script src="./index.js"></script>

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ resetBtn.addEventListener("click", () => {
 });
 
 trayToggle.addEventListener("change",()=>{
-  console.log('pin')
   window.electronAPI.toggleTrayStatus();
 })
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const startBtn = document.getElementById("startBtn");
 
 const progressBar = document.querySelector(".progress-bar");
 
+const trayToggle = document.getElementById('trayToggle');
+
 workInputLabel.innerText = workInput.value;
 restInputLabel.innerText = restInput.value;
 resetBtn.setAttribute("disabled", "disabled");
@@ -44,6 +46,11 @@ resetBtn.addEventListener("click", () => {
   resetBtn.setAttribute("disabled", "disabled");
   startBtn.removeAttribute("disabled");
 });
+
+trayToggle.addEventListener("change",()=>{
+  console.log('pin')
+  window.electronAPI.toggleTrayStatus();
+})
 
 window.electronAPI.handleProgress((event, value) => {
   progressBar.style.width = `${value}%`;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow, Notification, ipcMain } = require("electron");
+const { app, BrowserWindow, Notification, ipcMain,Tray,Menu } = require("electron");
 const path = require("path");
 
 let mainWindow;
@@ -7,6 +7,8 @@ let counter = 0;
 let isRunning = false;
 let workMinutes = 0;
 let restMinutes = 0;
+let appIcon = null;
+let isMinToTray = false;
 
 try {
   require("electron-reloader")(module);
@@ -30,6 +32,35 @@ function createWindow() {
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()
+/*------Handle Minimize window to tray-------*/
+  mainWindow.on('close', function (event) {
+    if(isMinToTray){   
+      event.preventDefault();
+      mainWindow.hide()
+    }
+});
+
+mainWindow.on('minimize', function (event) {
+  if(isMinToTray){   
+    event.preventDefault();
+    mainWindow.hide()
+  }
+})
+
+const contextMenu = Menu.buildFromTemplate([
+  { label: 'Show App', click:  function(){
+      mainWindow.show();
+  } },
+  { label: 'Quit', click:  function(){
+      mainWindow.destroy();
+      app.quit();
+  } }
+]);
+
+appIcon = new Tray(path.join("icon.ico"));
+appIcon.setToolTip('Electron.js App');
+appIcon.setContextMenu(contextMenu);
+
 }
 
 // const NOTIFICATION_TITLE = "Basic Notification";
@@ -92,11 +123,15 @@ function restTimer() {
   });
 }
 
+function toggleTrayStatus(){
+  isMinToTray = !isMinToTray
+}
+
 ipcMain.on("set-work-minutes", (e, minutes) => (workMinutes = minutes));
 ipcMain.on("set-rest-minutes", (e, minutes) => (restMinutes = minutes));
 ipcMain.on("start-timer", () => startTimer());
 ipcMain.on("stop-timer", () => stopTimer());
-
+ipcMain.on("toggle-tray-status",()=>toggleTrayStatus())
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.

--- a/preload.js
+++ b/preload.js
@@ -13,6 +13,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   setRestMinutes: (minutes) => ipcRenderer.send("set-rest-minutes", minutes),
   startTimer: () => ipcRenderer.send("start-timer"),
   stopTimer: () => ipcRenderer.send("stop-timer"),
-
+  toggleTrayStatus:()=>ipcRenderer.send("toggle-tray-status"),
   handleProgress: (callback) => ipcRenderer.on('update-progress', callback)
 });


### PR DESCRIPTION
# Issue
- Add option to minimize the window to tray

# Solution
## Index.html
- Added checkbox to toggle minimize to tray option
## Index.js
- Instantiated variable to capture Id of checkbox from index.html (_"trayToggle"_)
- Added eventListener("change") on "trayToggle" to toggle minimize option
## Preload.js
- Added _IpcRender.send("toggle-tray-status")_ method to _preload.js_ per commented instructions
## Main.js
- Deconstructed _Tray_ and _Menu_  from 'electron'
- Instantiated _appIcon_ and _isMinToTray_ (boolean) variables to facilitate a tray icon and toggle status for the option to minimize the app to the tray.
- Added 'on-minimize' and 'close' listeners  to facilitate tray minimize functionality
- Instantiated _contextMenu_  to provide options available from tray ("Show App" and "Quit").
## Preview of functionality
[minimize-app-to-tray.webm](https://user-images.githubusercontent.com/96255825/193738184-7e8715e5-cb22-4bf7-ac8e-58ecb25e3dec.webm)

