### PR TITLE
Fix the tray icon not showing on production build

### DIFF
--- a/main.js
+++ b/main.js
@@ -65,7 +65,10 @@ function createWindow() {
     }
   ]);
 
-  appIcon = new Tray(path.join("icon.ico"));
+  appIcon = new Tray(
+    // Find the correct path to the icon on the production build
+    app.isPackaged ? path.join(process.resourcesPath, "icon.ico") : "icon.ico"
+  );
   appIcon.setToolTip('PomoWorker');
   appIcon.setContextMenu(contextMenu);
   appIcon.on('double-click', () => mainWindow.show());

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
-    }
+    },
+    "extraResources": [
+      "./icon.ico"
+    ]
   },
   "repository": "https://github.com/mateusabelli/pomoworker",
   "author": "Mateus Abelli",


### PR DESCRIPTION
## Describe your changes

After packaging the application, the path of the tray icon would no
longer be the same as in the source files. To fix this, it was
implemented a ternary statement to check if the app is packaged or not,
if it is packaged then it will look for the icon in
`process.ResourcesPath`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
